### PR TITLE
Fix rate limit headers parser

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip

--- a/src/main/java/com/unikre/pixabay/PixabayClient.java
+++ b/src/main/java/com/unikre/pixabay/PixabayClient.java
@@ -27,13 +27,13 @@ public class PixabayClient {
     protected String apiKey;
 
     @Getter
-    protected int requestsLimitIn30min;
+    protected double requestsLimitIn30min;
 
     @Getter
-    protected int remainingRequests;
+    protected double remainingRequests;
 
     @Getter
-    protected int remainingSecsToResetLimit;
+    protected double remainingSecsToResetLimit;
 
     private static PixabayService pixabayService;
 
@@ -57,17 +57,17 @@ public class PixabayClient {
     private void parseRateLimit(Response response) {
         String value = response.headers().get("X-RateLimit-Limit");
         if (value != null && value.length() > 0) {
-            requestsLimitIn30min = Integer.parseInt(value);
+            requestsLimitIn30min = Double.parseDouble(value);
         }
 
         value = response.headers().get("X-RateLimit-Remaining");
         if (value != null && value.length() > 0) {
-            remainingRequests = Integer.parseInt(value);
+            remainingRequests = Double.parseDouble(value);
         }
 
         value = response.headers().get("X-RateLimit-Reset");
         if (value != null && value.length() > 0) {
-            remainingSecsToResetLimit = Integer.parseInt(value);
+            remainingSecsToResetLimit = Double.parseDouble(value);
         }
 
     }


### PR DESCRIPTION
Some time ago I started to get this stacktrace:

```
 java.lang.NumberFormatException: For input string: "0.72"
 	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
 	at java.base/java.lang.Integer.parseInt(Integer.java:652)
 	at java.base/java.lang.Integer.parseInt(Integer.java:770)
 	at com.unikre.pixabay.PixabayClient.parseRateLimit(PixabayClient.java:69)
 	at com.unikre.pixabay.PixabayClient.parseResponse(PixabayClient.java:88)
 	at com.unikre.pixabay.PixabayClient.searchImage(PixabayClient.java:121) 
```

Apparently pixabay is returning rate limit headers as float numbers (as opposed to expected integer)

This PR fixes it. 